### PR TITLE
Added support for arbitrary extension commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ on **Ubuntu** this package is in **multiverse**. See the *"Recommended"* section
 
 * `snmpd_default_monitors` [default: `true`]:
 * `snmpd_link_up_down_notifications` [default: `true`]:
+* `snmpd_extensions`: [default: `[]`]: List of extension names and commands
 
 ## Dependencies
 

--- a/templates/etc/snmp/snmpd.conf.j2
+++ b/templates/etc/snmp/snmpd.conf.j2
@@ -31,5 +31,11 @@ disk {{ snmpd_disk.path }} {{ snmpd_disk.threshold }}
 
 defaultMonitors         {{ 'yes' if snmpd_default_monitors else 'no' }}
 linkUpDownNotifications {{ 'yes' if snmpd_link_up_down_notifications else 'no' }}
+{% if snmpd_extensions is defined %}
+
+{% for snmpd_extension in snmpd_extensions %}
+extend {{ snmpd_extension.name }} {{ snmpd_extension.command }}
+{% endfor %}
+{% endif %}
 
 master agentx

--- a/templates/etc/snmp/snmpd.conf.j2
+++ b/templates/etc/snmp/snmpd.conf.j2
@@ -31,11 +31,9 @@ disk {{ snmpd_disk.path }} {{ snmpd_disk.threshold }}
 
 defaultMonitors         {{ 'yes' if snmpd_default_monitors else 'no' }}
 linkUpDownNotifications {{ 'yes' if snmpd_link_up_down_notifications else 'no' }}
-{% if snmpd_extensions is defined %}
 
-{% for snmpd_extension in snmpd_extensions %}
+{% for snmpd_extension in snmpd_extensions | default([]) %}
 extend {{ snmpd_extension.name }} {{ snmpd_extension.command }}
 {% endfor %}
-{% endif %}
 
 master agentx


### PR DESCRIPTION
Net-snmp allows you to configure extensions to run arbitrary commands. The resulting output and return code can be queried over snmp. This is a great feature that allows you to get a lot more mileage out of the humble snmpd daemon.

I've made a small addition to the configuration file template that allows you to define extensions like so:
```
snmpd_extensions:
  - name: 'system_architecture'
    command: /bin/uname -m
  - name: 'issue_file'
    command: /bin/cat /etc/issue
```

The resulting configuration looks like this:
```
extend system_architecture /bin/uname -m
extend issue_file /bin/cat /etc/issue
```

After the service is (re)started, these extensions are made available under NET-SNMP-EXTEND-MIB (.1.3.6.1.4.1.8072.1.3.1).  A very useful OID to query (in my opinion) is NET-SNMP-EXTEND-MIB::nsExtendOutput1Line, which returns the first line of output of the command.

```
~$ snmpwalk -v3 -u user -a SHA -A "authsecret" -x AES -X "cryptsecret" -l authPriv foo.example.org NET-SNMP-EXTEND-MIB::nsExtendOutput1Line
NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."issue_file" = STRING: Ubuntu 18.04 LTS \\n \\l
NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."system_architecture" = STRING: x86_64
```

I did not any extension to the defaults file, making this an entirely optional feature.

Upstream documentation for this feature of net-snmp:
- http://net-snmp.sourceforge.net/wiki/index.php/Tut:Extending_snmpd_using_shell_scripts
- http://net-snmp.sourceforge.net/docs/man/snmpd.conf.html#lbAZ

Great piece of documentation by Red Hat:
- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/sect-system_monitoring_tools-net-snmp-extending