### PR TITLE
Added sysServices configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ snmpd_users:
 snmpd_sys_location: 'Unknown'
 snmpd_sys_contact: Root <root@localhost>
 snmpd_sys_description: "{{ inventory_hostname }}"
+snmpd_sys_services: 72
 
 snmpd_disks_include_all: false
 snmpd_disks_include_all_threshold: '10%'

--- a/templates/etc/snmp/snmpd.conf.j2
+++ b/templates/etc/snmp/snmpd.conf.j2
@@ -18,6 +18,7 @@ rouser authOnlyUser
 sysLocation {{ snmpd_sys_location }}
 sysContact  {{ snmpd_sys_contact }}
 sysDescr  {{ snmpd_sys_description }}
+sysServices  {{ snmpd_sys_services }}
 
 iquerySecName {{ snmpd_internal_user.username }}
 rouser        {{ snmpd_internal_user.username }}


### PR DESCRIPTION
The option was missing from ansible variables, making it impossible to get more detailed information in tools such as Observium without manually editing configuration.

