### PR TITLE
Config update

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ snmpd_users:
 snmpd_sys_location: 'Unknown'
 snmpd_sys_contact: Root <root@localhost>
 snmpd_sys_description: "{{ inventory_hostname }}"
+snmpd_sys_services: 72
 
 snmpd_disks_include_all: false
 snmpd_disks_include_all_threshold: '10%'

--- a/templates/etc/snmp/snmpd.conf.j2
+++ b/templates/etc/snmp/snmpd.conf.j2
@@ -18,6 +18,7 @@ rouser authOnlyUser
 sysLocation {{ snmpd_sys_location }}
 sysContact  {{ snmpd_sys_contact }}
 sysDescr  {{ snmpd_sys_description }}
+sysServices  {{ snmpd_sys_services }}
 
 iquerySecName {{ snmpd_internal_user.username }}
 rouser        {{ snmpd_internal_user.username }}

--- a/templates/etc/snmp/snmpd.conf.j2
+++ b/templates/etc/snmp/snmpd.conf.j2
@@ -17,8 +17,10 @@ rouser authOnlyUser
 
 sysLocation {{ snmpd_sys_location }}
 sysContact  {{ snmpd_sys_contact }}
-sysDescr  {{ snmpd_sys_description }}
-sysServices  {{ snmpd_sys_services }}
+{% if snmpd_sys_description %}
+sysDescr    {{ snmpd_sys_description }}
+{% endif %}
+sysServices {{ snmpd_sys_services }}
 
 iquerySecName {{ snmpd_internal_user.username }}
 rouser        {{ snmpd_internal_user.username }}


### PR DESCRIPTION
Added sysServices configuration option to control level of information transferred. 

Made sysDescr optional. In Debian systems this will fill the variable with 'uname -a' data, which can be further parsed (for example by Observium which will start reporting kernel version ).