### PR TITLE
Stop the service and remove the /var/lib/snmp/snmpd.conf before editing the config files

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,20 @@
     - snmpd
     - snmpd-install
 
+- name: stop the snmp service for editing
+  ansible.builtin.service:
+    name: snmpd
+    state: "stopped"
+  tags:
+    - configuration
+    - snmpd
+    - snmpd-start-stop-service
+
+- name: delete the old snmp /var/lib/snmp/snmpd.conf
+  ansible.builtin.file:
+    state: absent
+    path: /var/lib/snmp/snmpd.conf
+
 - name: update configuration file - /etc/default/snmpd.conf
   ansible.builtin.template:
     src: etc/default/snmpd.j2


### PR DESCRIPTION
This fixes an issue where the generates hashes are not being re-generated on Debian. Stopping the previous service, deleting the file will cause snmpd to re-generate the /var/lib/snmp/snmpd.conf config file with the new authentication hashes.

Disclamer: did not test this on Ubuntu